### PR TITLE
small cleanup in QGeoTileFetcherGooglemaps and questions

### DIFF
--- a/qgeotilefetchergooglemaps.cpp
+++ b/qgeotilefetchergooglemaps.cpp
@@ -50,32 +50,13 @@ QGeoTileFetcherGooglemaps::QGeoTileFetcherGooglemaps(const QVariantMap &paramete
         _userAgent = parameters.value(QStringLiteral("googlemaps.useragent")).toString().toLatin1();
     else
         _userAgent = "";
-//        _userAgent = "Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/31.0";
-
     QStringList langs = QLocale::system().uiLanguages();
     if (langs.length() > 0) {
         _language = langs[0];
     }
 
     // Google version strings
-    _versionGoogleMap            = "m@338000000";
-    _versionGoogleSatellite      = "198";
-    _versionGoogleLabels         = "h@336";
-    _versionGoogleTerrain        = "t@132,r@338000000";
     _secGoogleWord               = "Galileo";
-
-//    _tryCorrectGoogleVersions(m_networkManager);
-
-//    netRequest.setRawHeader("Referrer", "https://www.google.com/maps/preview");
-//    netRequest.setRawHeader("Accept", "*/*");
-//    netRequest.setRawHeader("User-Agent", _userAgent);
-
-    /*  2017: support new Google Maps Tile API (yet under development)
-        You have to be whitelisted to use the Tile API. I can't tell how to get whitelisted.
-        see https://developers.google.com/maps/documentation/tile/
-        To use the new feature getUrl() and parsing the response has to be adapted. Maybe more than that...
-    */
-//    _getSessionToken();
 }
 
 QGeoTileFetcherGooglemaps::~QGeoTileFetcherGooglemaps()
@@ -195,24 +176,6 @@ void QGeoTileFetcherGooglemaps::_googleVersionCompleted()
         qDebug() << "Error collecting Google maps version info";
         return;
     }
-    QString html = QString(_googleReply->readAll());
-
-    QRegExp reg("\"*https?://mt\\D?\\d..*/vt\\?lyrs=m@(\\d*)", Qt::CaseInsensitive);
-    if (reg.indexIn(html) != -1) {
-        QStringList gc = reg.capturedTexts();
-        _versionGoogleMap = QString("m@%1").arg(gc[1]);
-    }
-    reg = QRegExp("\"*https?://khm\\D?\\d.googleapis.com/kh\\?v=(\\d*)", Qt::CaseInsensitive);
-    if (reg.indexIn(html) != -1) {
-        QStringList gc = reg.capturedTexts();
-        _versionGoogleSatellite = gc[1];
-    }
-    reg = QRegExp("\"*https?://mt\\D?\\d..*/vt\\?lyrs=t@(\\d*),r@(\\d*)", Qt::CaseInsensitive);
-    if (reg.indexIn(html) != -1) {
-        QStringList gc = reg.capturedTexts();
-        _versionGoogleTerrain = QString("t@%1,r@%2").arg(gc[1]).arg(gc[2]);
-    }
-
     _googleReply->deleteLater();
     _googleReply = NULL;
 }

--- a/qgeotilefetchergooglemaps.cpp
+++ b/qgeotilefetchergooglemaps.cpp
@@ -20,16 +20,6 @@
 
 QT_BEGIN_NAMESPACE
 
-namespace
-{
-
-    int _getServerNum(int x, int y, int max)
-    {
-        return (x + 2 * y) % max;
-    }
-
-}
-
 QGeoTileFetcherGooglemaps::QGeoTileFetcherGooglemaps(const QVariantMap &parameters,
                                            QGeoTiledMappingManagerEngineGooglemaps *engine,
                                            const QSize &tileSize)

--- a/qgeotilefetchergooglemaps.h
+++ b/qgeotilefetchergooglemaps.h
@@ -49,19 +49,13 @@ private:
     QString m_client;
     QString m_baseUri;
 
-    int             _timeout;
     bool            _googleVersionRetrieved;
     QNetworkReply*  _googleReply;
     QMutex          _googleVersionMutex;
     QByteArray      _userAgent;
     QString         _language;
-    QJsonValue      _sessionToken;
 
     // Google version strings
-    QString         _versionGoogleMap;
-    QString         _versionGoogleSatellite;
-    QString         _versionGoogleLabels;
-    QString         _versionGoogleTerrain;
     QString         _secGoogleWord;
 
     QNetworkRequest netRequest;


### PR DESCRIPTION
hello Vladyslav,

i'm participating in a open source project where we just recently added a Qt Location based map widget:
https://github.com/Subsurface-divelog/subsurface

after not being happy with the bundled ESRI geolocation plugin, we found your google maps plugin, for which we would like to thank you - it works and it seems to suit our needs for now! we are probably going to fork your repository and always base our builds on that, but still send patches and PRs upstream back to you:
https://github.com/Subsurface-divelog/googlemaps

in this PR there are a couple of small changes that remove some unused variables and code from QGeoTileFetcherGooglemaps. i'm not exactly sure if there are plans to keep this code for later or if it's for debugging purposes, so please let me know if my changes are not appropriate.

thanks
lubomir
