### PR TITLE
support language as a PluginParameter

### DIFF
--- a/qgeotilefetchergooglemaps.cpp
+++ b/qgeotilefetchergooglemaps.cpp
@@ -114,7 +114,7 @@ QString QGeoTileFetcherGooglemaps::_getURL(int type, int x, int y, int zoom)
         QString sec1    = ""; // after &x=...
         QString sec2    = ""; // after &zoom=...
         _getSecGoogleWords(x, y, sec1, sec2);
-        return QString("http://mt.google.com/vt/lyrs=m&x=%1%2&y=%3&z=%4&s=%5").arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
+        return QString("http://mt.google.com/vt/lyrs=m&hl=%1&x=%2%3&y=%4&z=%5&s=%6").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
     }
     break;
     case 2: //Satallite Map

--- a/qgeotilefetchergooglemaps.cpp
+++ b/qgeotilefetchergooglemaps.cpp
@@ -40,9 +40,13 @@ QGeoTileFetcherGooglemaps::QGeoTileFetcherGooglemaps(const QVariantMap &paramete
         _userAgent = parameters.value(QStringLiteral("googlemaps.useragent")).toString().toLatin1();
     else
         _userAgent = "";
-    QStringList langs = QLocale::system().uiLanguages();
-    if (langs.length() > 0) {
-        _language = langs[0];
+    if (parameters.contains(QStringLiteral("googlemaps.maps.language"))) {
+        _language = parameters.value(QStringLiteral("googlemaps.maps.language")).toString().toLatin1();
+        if (_language.isEmpty())
+           _language = "en-US";
+    } else {
+        QStringList langs = QLocale::system().uiLanguages();
+        _language = (langs.length() > 0) ? langs[0] : "en-US";
     }
 
     // Google version strings


### PR DESCRIPTION
hello,

this PR has a couple of patches:
- support the "googlemaps.maps.language" plugin parameter to be able to pass ISO language string from QML
if for some reason no language is set, it falls back to "en-US".
- use the _language member variable for the Road map as well (`&hl=<value of _language>`)
