### PR TITLE
Remove unnecessary dependency on positioning-private

### DIFF
--- a/googlemaps.pro
+++ b/googlemaps.pro
@@ -1,5 +1,5 @@
 TARGET = qtgeoservices_googlemaps
-QT += location-private positioning-private network
+QT += location-private network
 
 PLUGIN_TYPE = geoservices
 PLUGIN_CLASS_NAME = QGeoServiceProviderFactoryGooglemaps


### PR DESCRIPTION
The module compiles fine without it (and looking through the sources doesn't
appear to pull in any private headers from qtpositioning).

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>