### PR TITLE
Revert "Remove unnecessary dependency on positioning-private"

### DIFF
--- a/googlemaps.pro
+++ b/googlemaps.pro
@@ -1,5 +1,5 @@
 TARGET = qtgeoservices_googlemaps
-QT += location-private network
+QT += location-private positioning-private network
 
 PLUGIN_TYPE = geoservices
 PLUGIN_CLASS_NAME = QGeoServiceProviderFactoryGooglemaps


### PR DESCRIPTION
It turns out that my testing of this was flawed and that indeed the
positioning-private headers are pulled in indeirectly throught the
location-private headers. My apologies for the noise.

This reverts commit 5201d10f1e4ac3733bb95c7f8722f023ce748291.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>