### PR TITLE
qmake: handle missing private headers

### DIFF
--- a/googlemaps.pro
+++ b/googlemaps.pro
@@ -1,5 +1,17 @@
 TARGET = qtgeoservices_googlemaps
-QT += location-private positioning-private network
+
+qtHaveModule(location-private) {
+	QT += location-private
+} else {
+	QT += location
+}
+qtHaveModule(positioning-private) {
+	QT += positioning-private
+} else {
+	QT += positioning
+}
+QT += network
+INCLUDEPATH += ../ ./
 
 PLUGIN_TYPE = geoservices
 PLUGIN_CLASS_NAME = QGeoServiceProviderFactoryGooglemaps


### PR DESCRIPTION
Use qtHaveModule() (requires qmake5) to determine
if the following modules are available:
    location-private
    positioning-private

If these modules exists add them to the QT variable.
If not use the following modules instead:
    location
    positioning

The reason for this change is that on recent Ubuntu and Debian
the QtLocation and QtPositioning private headers, simply do
not exists as packages. So what one has to do is download them
manually either from the whole binary package of Qt or from the
source code repository and place them in "QtLocation" or in
"QtPositioning" folders under ./ or under ../. The alternative
is to have root access and install them in the folder which
contains the rest of the Qt headers.

By adding ./ and ../ in INCLUDEPATH, we add the option for the
user to use the parent or local directory for these headers.

Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>