### PR TITLE
Use supported way to create a plugin

### DIFF
--- a/googlemaps.pro
+++ b/googlemaps.pro
@@ -1,4 +1,13 @@
+TEMPLATE = lib
+CONFIG += plugin
+CONFIG += relative_qt_rpath  # Qt's plugins should be relocatable
 TARGET = qtgeoservices_googlemaps
+PLUGIN_TYPE = geoservices
+PLUGIN_CLASS_NAME = QGeoServiceProviderFactoryGooglemaps
+target.path = $$[QT_INSTALL_PLUGINS]/$$PLUGIN_TYPE
+INSTALLS += target
+TARGET = $$qt5LibraryTarget($$TARGET)
+
 
 qtHaveModule(location-private) {
 	QT += location-private
@@ -12,10 +21,6 @@ qtHaveModule(positioning-private) {
 }
 QT += network
 INCLUDEPATH += ../ ./
-
-PLUGIN_TYPE = geoservices
-PLUGIN_CLASS_NAME = QGeoServiceProviderFactoryGooglemaps
-load(qt_plugin)
 
 HEADERS += \
     qgeoserviceproviderplugingooglemaps.h \


### PR DESCRIPTION
Reading through the qmake documentation you aren't supposed to just
load(qt_plugin) - and as a matter of fact this fails for certain situations on
Mac. Using the right `TEMPLATE` and `CONFIG` seems to fix the problem.

Please check that this doesn't break anything for you 