### PR TITLE
Fix map tile cache not working on windows for non ASCII cachefolder

### DIFF
--- a/qgeotiledmappingmanagerenginegooglemaps.cpp
+++ b/qgeotiledmappingmanagerenginegooglemaps.cpp
@@ -62,7 +62,7 @@ QGeoTiledMappingManagerEngineGooglemaps::QGeoTiledMappingManagerEngineGooglemaps
     setTileFetcher(fetcher);
 
     if (parameters.contains(QStringLiteral("googlemaps.cachefolder")))
-        m_cacheDirectory = parameters.value(QStringLiteral("googlemaps.cachefolder")).toString().toLatin1();
+        m_cacheDirectory = parameters.value(QStringLiteral("googlemaps.cachefolder")).toString();
 
     const int szCache = 100 * 1024 * 1024;
 #if QT_VERSION < QT_VERSION_CHECK(5,6,0)


### PR DESCRIPTION
This issue was found using the plugin in Subsurface
There cachefolder is configured to use path to current user's AppData
In my case the user name contains non ASCII char (é)
The call to 'toLatin1' trans-coded the char that was then badly
 interpreted by QString assignment operator.
See http://doc.qt.io/qt-5/qstring.html#operator-eq-5
'The byte array is converted to Unicode using the fromUtf8() function.'

It resulted in Qt not being able to create the cached files:
'QIODevice::write (QFile, "C:\Users\J?r?mie\AppData\Roaming\
'Subsurface\googlemaps\googlemaps_100-2-12-2046-1362.jpeg"): '
'device not open'

Signed-off-by: Jeremie Guichard <djebrest@gmail.com>