### PR TITLE
Enable downloading tiles for High DPI displays

### DIFF
--- a/qgeotilefetchergooglemaps.cpp
+++ b/qgeotilefetchergooglemaps.cpp
@@ -27,7 +27,8 @@ QGeoTileFetcherGooglemaps::QGeoTileFetcherGooglemaps(const QVariantMap &paramete
   m_networkManager(new QNetworkAccessManager(this)),
   m_engineGooglemaps(engine),
   m_tileSize(tileSize),
-  _googleVersionRetrieved(false)
+  _googleVersionRetrieved(false),
+  _scale(1)
 {
     if(parameters.contains(QStringLiteral("googlemaps.maps.apikey")))
         m_apiKey = parameters.value(QStringLiteral("googlemaps.maps.apikey")).toString();
@@ -48,6 +49,9 @@ QGeoTileFetcherGooglemaps::QGeoTileFetcherGooglemaps(const QVariantMap &paramete
         QStringList langs = QLocale::system().uiLanguages();
         _language = (langs.length() > 0) ? langs[0] : "en-US";
     }
+
+    if (parameters.contains(QStringLiteral("googlemaps.maps.highdpi")))
+        _scale = (parameters.value(QStringLiteral("googlemaps.maps.highdpi")).toBool()) ? 2 : 1;
 
     // Google version strings
     _secGoogleWord               = "Galileo";
@@ -118,7 +122,7 @@ QString QGeoTileFetcherGooglemaps::_getURL(int type, int x, int y, int zoom)
         QString sec1    = ""; // after &x=...
         QString sec2    = ""; // after &zoom=...
         _getSecGoogleWords(x, y, sec1, sec2);
-        return QString("http://mt.google.com/vt/lyrs=m&hl=%1&x=%2%3&y=%4&z=%5&s=%6").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
+        return QString("http://mt.google.com/vt/lyrs=m&hl=%1&x=%2%3&y=%4&z=%5&s=%6&scale=%7").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2).arg(_scale);
     }
     break;
     case 2: //Satallite Map
@@ -126,7 +130,7 @@ QString QGeoTileFetcherGooglemaps::_getURL(int type, int x, int y, int zoom)
         QString sec1    = ""; // after &x=...
         QString sec2    = ""; // after &zoom=...
         _getSecGoogleWords(x, y, sec1, sec2);
-        return QString("http://mt.google.com/vt/lyrs=s&hl=%1&x=%2%3&y=%4&z=%5&s=%6").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
+        return QString("http://mt.google.com/vt/lyrs=s&hl=%1&x=%2%3&y=%4&z=%5&s=%6&scale=%7").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2).arg(_scale);
     }
     break;
     case 3: //Terrain Map
@@ -134,7 +138,7 @@ QString QGeoTileFetcherGooglemaps::_getURL(int type, int x, int y, int zoom)
         QString sec1    = ""; // after &x=...
         QString sec2    = ""; // after &zoom=...
         _getSecGoogleWords(x, y, sec1, sec2);
-        return QString("http://mt.google.com/vt/lyrs=p&hl=%1&x=%2%3&y=%4&z=%5&s=%6").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
+        return QString("http://mt.google.com/vt/lyrs=p&hl=%1&x=%2%3&y=%4&z=%5&s=%6&scale=%7").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2).arg(_scale);
     }
     break;
     case 4: //Hybrid Map
@@ -142,7 +146,7 @@ QString QGeoTileFetcherGooglemaps::_getURL(int type, int x, int y, int zoom)
         QString sec1    = ""; // after &x=...
         QString sec2    = ""; // after &zoom=...
         _getSecGoogleWords(x, y, sec1, sec2);
-        return QString("http://mt.google.com/vt/lyrs=y&hl=%1&x=%2%3&y=%4&z=%5&s=%6").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
+        return QString("http://mt.google.com/vt/lyrs=y&hl=%1&x=%2%3&y=%4&z=%5&s=%6&scale=%7").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2).arg(_scale);
     }
     break;
     }

--- a/qgeotilefetchergooglemaps.cpp
+++ b/qgeotilefetchergooglemaps.cpp
@@ -134,7 +134,7 @@ QString QGeoTileFetcherGooglemaps::_getURL(int type, int x, int y, int zoom)
         QString sec1    = ""; // after &x=...
         QString sec2    = ""; // after &zoom=...
         _getSecGoogleWords(x, y, sec1, sec2);
-        return QString("http://mt.google.com/vt/lyrs=p&hl=%5&x=%6%7&y=%8&z=%9&s=%10").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
+        return QString("http://mt.google.com/vt/lyrs=p&hl=%1&x=%2%3&y=%4&z=%5&s=%6").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
     }
     break;
     case 4: //Hybrid Map
@@ -142,7 +142,7 @@ QString QGeoTileFetcherGooglemaps::_getURL(int type, int x, int y, int zoom)
         QString sec1    = ""; // after &x=...
         QString sec2    = ""; // after &zoom=...
         _getSecGoogleWords(x, y, sec1, sec2);
-        return QString("http://mt.google.com/vt/lyrs=y&hl=%5&x=%6%7&y=%8&z=%9&s=%10").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
+        return QString("http://mt.google.com/vt/lyrs=y&hl=%1&x=%2%3&y=%4&z=%5&s=%6").arg(_language).arg(x).arg(sec1).arg(y).arg(zoom).arg(sec2);
     }
     break;
     }

--- a/qgeotilefetchergooglemaps.h
+++ b/qgeotilefetchergooglemaps.h
@@ -54,6 +54,7 @@ private:
     QMutex          _googleVersionMutex;
     QByteArray      _userAgent;
     QString         _language;
+    int             _scale;
 
     // Google version strings
     QString         _secGoogleWord;


### PR DESCRIPTION
Signed-off-by: Murillo Bernardes <mfbernardes@gmail.com>

Add support to maps api scale parameter, as documented in https://developers.google.com/maps/documentation/maps-static/intro#scale_values.

Example of new vs current.

Current | High DPI
------------ | -------------
![qtgmaps-current](https://user-images.githubusercontent.com/30494/40754085-a8a46816-6477-11e8-8f1c-11c8b4463507.PNG) | ![qtgmaps-highdpi](https://user-images.githubusercontent.com/30494/40754086-a8c4acfc-6477-11e8-9088-ecfec1bbc2ad.PNG)

@dirkhh 